### PR TITLE
Fix project creation with relative paths in web UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,5 @@
 // Load environment variables from .env file
-import fs from 'fs';
+import fs, { promises as fsPromises } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
@@ -29,8 +29,6 @@ import express from 'express';
 import { WebSocketServer } from 'ws';
 import http from 'http';
 import cors from 'cors';
-import { promises as fsPromises } from 'fs';
-import fs from 'fs';
 import { spawn } from 'child_process';
 import os from 'os';
 import pty from 'node-pty';

--- a/server/projects.js
+++ b/server/projects.js
@@ -666,7 +666,15 @@ async function deleteProject(projectName) {
 
 // Add a project manually to the config (without creating folders)
 async function addProjectManually(projectPath, displayName = null) {
-  const absolutePath = path.resolve(projectPath);
+  let absolutePath;
+  
+  // If the path is absolute, use it as is
+  if (path.isAbsolute(projectPath)) {
+    absolutePath = path.resolve(projectPath);
+  } else {
+    // If it's a relative path, resolve it against PROJECTS_PATH
+    absolutePath = path.resolve(getProjectsPath(), projectPath);
+  }
   
   try {
     // Check if the path exists


### PR DESCRIPTION
## Summary
- Fixed addProjectManually function to properly handle relative paths
- Relative paths now resolve against PROJECTS_PATH environment variable instead of current working directory  
- Absolute paths continue to work as before

## Problem
When users entered relative paths like "test" in the web UI project creation form, the system would resolve it against the current working directory (e.g., `/app/test` in Docker) instead of the configured PROJECTS_PATH, resulting in "Path does not exist" errors.

## Solution
Modified the path resolution logic in `addProjectManually()` to:
- Check if input path is absolute using `path.isAbsolute()`
- If absolute: use as-is with `path.resolve(projectPath)`
- If relative: resolve against PROJECTS_PATH with `path.resolve(getProjectsPath(), projectPath)`

## Test plan
- [ ] Test absolute paths (e.g., `/home/user/project`) - should work as before
- [ ] Test relative paths (e.g., `test`) - should resolve to `PROJECTS_PATH/test`
- [ ] Verify PROJECTS_PATH environment variable is respected
- [ ] Test in both Docker and native environments

🤖 Generated with [Claude Code](https://claude.ai/code)