### PR TITLE
Fix undefined directory path in project creation success messages

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -340,14 +340,20 @@ function Sidebar({
 
       if (response.ok) {
         const result = await response.json();
+        
+        // Validate server response structure
+        if (!result.project) {
+          throw new Error('Invalid server response: missing project data');
+        }
+        
         setShowNewProject(false);
         setNewProjectPath('');
         
         // Show success message indicating if directory was created
-        if (result.project.directoryCreated) {
-          alert(`Project created successfully! Directory created at: ${result.project.path}`);
+        if (result.project?.directoryCreated) {
+          alert(`Project created successfully! Directory created at: ${result.project?.path}`);
         } else {
-          alert(`Project added successfully! Using existing directory: ${result.project.path}`);
+          alert(`Project added successfully! Using existing directory: ${result.project?.path}`);
         }
         
         // Refresh projects to show the new one

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -350,10 +350,10 @@ function Sidebar({
         setNewProjectPath('');
         
         // Show success message indicating if directory was created
-        if (result.project?.directoryCreated) {
-          alert(`Project created successfully! Directory created at: ${result.project?.path}`);
+        if (result.project.directoryCreated) {
+          alert(`Project created successfully! Directory created at: ${result.project.path}`);
         } else {
-          alert(`Project added successfully! Using existing directory: ${result.project?.path}`);
+          alert(`Project added successfully! Using existing directory: ${result.project.path}`);
         }
         
         // Refresh projects to show the new one

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -366,7 +366,7 @@ function Sidebar({
     } finally {
       setCreatingProject(false);
     }
-  };;
+  };
 
   const cancelNewProject = () => {
     setShowNewProject(false);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -344,10 +344,10 @@ function Sidebar({
         setNewProjectPath('');
         
         // Show success message indicating if directory was created
-        if (result.directoryCreated) {
-          alert(`Project created successfully! Directory created at: ${result.path}`);
+        if (result.project.directoryCreated) {
+          alert(`Project created successfully! Directory created at: ${result.project.path}`);
         } else {
-          alert(`Project added successfully! Using existing directory: ${result.path}`);
+          alert(`Project added successfully! Using existing directory: ${result.project.path}`);
         }
         
         // Refresh projects to show the new one
@@ -366,7 +366,7 @@ function Sidebar({
     } finally {
       setCreatingProject(false);
     }
-  };
+  };;
 
   const cancelNewProject = () => {
     setShowNewProject(false);
@@ -519,7 +519,7 @@ function Sidebar({
             <Input
               value={newProjectPath}
               onChange={(e) => setNewProjectPath(e.target.value)}
-              placeholder=\"/path/to/project (will create if doesn't exist)\"
+              placeholder="/path/to/project (will create if doesn't exist)"
               className="text-sm focus:ring-2 focus:ring-primary/20"
               autoFocus
               onKeyDown={(e) => {
@@ -573,7 +573,7 @@ function Sidebar({
                 <Input
                   value={newProjectPath}
                   onChange={(e) => setNewProjectPath(e.target.value)}
-                  placeholder=\"/path/to/project (will create if doesn't exist)\"
+                  placeholder="/path/to/project (will create if doesn't exist)"
                   className="text-sm h-10 rounded-md focus:border-primary transition-colors"
                   autoFocus
                   onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- Fixed frontend property access to correctly reference nested project object structure
- Resolves issue where project creation success messages displayed "undefined" instead of actual directory path

## Problem
The frontend was accessing `result.path` and `result.directoryCreated` directly from the API response, but the server returns these properties nested under a `project` object as `{ success: true, project: { path: "...", directoryCreated: true/false } }`.

## Solution  
Modified the `createNewProject` function in `src/components/Sidebar.jsx` to use:
- `result.project.path` instead of `result.path`
- `result.project.directoryCreated` instead of `result.directoryCreated`

## Test Plan
- [x] Verified server response structure in `server/index.js` and `server/projects.js`
- [x] Applied fix to frontend property access
- [x] Tested project creation with existing directory (shows correct path)
- [x] Tested project creation with new directory (shows correct path)

🤖 Generated with [Claude Code](https://claude.ai/code)