### PR TITLE
Add PROJECT_BASE_DIR environment variable for custom project folder creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,8 @@ VITE_PORT=5173
 # PROJECTS_PATH=
 
 # Base directory for creating new project folders (default: /workspace)
+# Security note: Must be an absolute path, cannot be system directories
+# Recommended: Use dedicated project directories like /workspace, /projects  
 # This controls where actual project working directories are created.
 # Claude sessions are always stored separately in ~/.claude/projects
 # PROJECT_BASE_DIR=/workspace

--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,8 @@ VITE_PORT=5173
 # [Deprecated] Overrides the default projects directory.
 # The default path (~/.claude/projects) is recommended.
 # PROJECTS_PATH=
+
+# Base directory for creating new project folders (default: /workspace)
+# This controls where actual project working directories are created.
+# Claude sessions are always stored separately in ~/.claude/projects
+# PROJECT_BASE_DIR=/workspace

--- a/server/projects.test.js
+++ b/server/projects.test.js
@@ -289,4 +289,26 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     consoleSpy.mockRestore();
     process.env.NODE_ENV = originalEnv;
   });
+
+  it('should validate enhanced path validation logic', async () => {
+    // This test verifies the enhanced Windows drive letter validation logic exists
+    // We test it by checking error messages from the validation function
+    
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    
+    try {
+      // Simulate the validation logic being called with an invalid Windows path
+      // The path.isAbsolute will return false for paths without proper drive letters
+      process.env.PROJECT_BASE_DIR = '\\InvalidPath';
+      
+      await expect(addProjectManually('test-project')).rejects.toThrow(
+        'PROJECT_BASE_DIR는 절대 경로여야 합니다'
+      );
+    } finally {
+      // Always restore original platform
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+  });
+
 });

--- a/server/projects.test.js
+++ b/server/projects.test.js
@@ -66,16 +66,16 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     process.env.PROJECT_BASE_DIR = '/safe/projects';
 
     await expect(addProjectManually('../../../etc/passwd')).rejects.toThrow(
-      'Invalid project path. Directory traversal attempts are not allowed.'
+      '유효하지 않은 프로젝트 경로입니다. 디렉토리 순회 시도는 허용되지 않습니다.'
     );
   });
 
   it('should validate project names correctly', async () => {
     process.env.PROJECT_BASE_DIR = '/test/projects';
 
-    await expect(addProjectManually('')).rejects.toThrow('Invalid project name');
-    await expect(addProjectManually('.')).rejects.toThrow('Invalid project name');
-    await expect(addProjectManually('..')).rejects.toThrow('Invalid project name');
+    await expect(addProjectManually('')).rejects.toThrow('유효하지 않은 프로젝트 이름입니다');
+    await expect(addProjectManually('.')).rejects.toThrow('유효하지 않은 프로젝트 이름입니다');
+    await expect(addProjectManually('..')).rejects.toThrow('유효하지 않은 프로젝트 이름입니다');
   });
 
   it('should generate correct project identifier for session linking', async () => {
@@ -99,7 +99,7 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
       process.env.PROJECT_BASE_DIR = systemDir + '/sensitive';
       
       await expect(addProjectManually('test-project')).rejects.toThrow(
-        'PROJECT_BASE_DIR cannot be set to system directories'
+        'PROJECT_BASE_DIR는 시스템 디렉토리로 설정할 수 없습니다'
       );
     }
   });
@@ -108,18 +108,18 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     process.env.PROJECT_BASE_DIR = './relative/path';
     
     await expect(addProjectManually('test-project')).rejects.toThrow(
-      'PROJECT_BASE_DIR must be an absolute path'
+      'PROJECT_BASE_DIR는 절대 경로여야 합니다'
     );
   });
 
   it('should handle Windows-style path separators', async () => {
     // Test multiple Windows-style patterns
     await expect(addProjectManually('..\\sensitive')).rejects.toThrow(
-      'Invalid project path. Directory traversal attempts are not allowed.'
+      '유효하지 않은 프로젝트 경로입니다. 디렉토리 순회 시도는 허용되지 않습니다.'
     );
     
     await expect(addProjectManually('..\\..\\etc\\passwd')).rejects.toThrow(
-      'Invalid project path. Directory traversal attempts are not allowed.'
+      '유효하지 않은 프로젝트 경로입니다. 디렉토리 순회 시도는 허용되지 않습니다.'
     );
   });
 
@@ -136,7 +136,7 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     });
 
     await expect(addProjectManually('test')).rejects.toThrow(
-      "Security violation: Project path is outside allowed base directory '/safe/projects'"
+      "보안 위반: 프로젝트 경로가 허용된 기본 디렉토리를 벗어났습니다 '/safe/projects'"
     );
 
     path.resolve.mockRestore();
@@ -192,15 +192,16 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
   });
 
   it('should handle extremely long paths that exceed OS limits', async () => {
-    // Test path length limits (OS-specific MAX_PATH)
-    const veryLongBasePath = '/tmp/' + 'very-long-directory-name/'.repeat(20);
-    process.env.PROJECT_BASE_DIR = veryLongBasePath;
+    // Test path length limits with reasonable base path but very long project name
+    process.env.PROJECT_BASE_DIR = '/tmp/test';
     
     const fs = await import('fs');
     fs.promises.access.mockRejectedValue({ code: 'ENOENT' });
+    fs.promises.realpath.mockRejectedValue({ code: 'ENOENT' });
     fs.promises.mkdir.mockRejectedValue({ code: 'ENAMETOOLONG', message: 'File name too long' });
     
-    await expect(addProjectManually('project')).rejects.toThrow('경로 이름이 너무 깁니다');
+    const longProjectName = 'a'.repeat(300); // Very long project name
+    await expect(addProjectManually(longProjectName)).rejects.toThrow('경로 이름이 너무 깁니다');
   });
 
   it('should validate path normalization edge cases', async () => {
@@ -216,7 +217,7 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     for (const testCase of testCases) {
       if (testCase.includes('..') || !path.isAbsolute(testCase)) {
         await expect(addProjectManually(testCase)).rejects.toThrow(
-          'Invalid project path. Directory traversal attempts are not allowed.'
+          '유효하지 않은 프로젝트 경로입니다. 디렉토리 순회 시도는 허용되지 않습니다.'
         );
       }
     }
@@ -247,7 +248,7 @@ describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
     fs.promises.realpath.mockResolvedValue('/unsafe/location');
     
     await expect(addProjectManually('symlink-project')).rejects.toThrow(
-      'Security violation: Symbolic link traversal attempt detected'
+      '보안 위반: 심볼릭 링크를 통한 디렉토리 순회 시도가 감지되었습니다'
     );
   });
 

--- a/server/projects.test.js
+++ b/server/projects.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { addProjectManually } from './projects.js';
+import path from 'path';
+
+// Mock fs module
+vi.mock('fs', () => ({
+  promises: {
+    access: vi.fn(),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue('{}'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock path utilities
+vi.mock('./utils/paths.js', () => ({
+  getClaudeDir: vi.fn(() => '/mock/.claude'),
+}));
+
+describe('addProjectManually - PROJECT_BASE_DIR functionality', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env.PROJECT_BASE_DIR;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.PROJECT_BASE_DIR = originalEnv;
+    } else {
+      delete process.env.PROJECT_BASE_DIR;
+    }
+  });
+
+  it('should use /workspace as default when PROJECT_BASE_DIR is not set', async () => {
+    delete process.env.PROJECT_BASE_DIR;
+    
+    const fs = await import('fs');
+    fs.promises.access.mockRejectedValue({ code: 'ENOENT' });
+
+    const result = await addProjectManually('test-project');
+
+    expect(result.path).toBe(path.resolve('/workspace/test-project'));
+    expect(result.fullPath).toBe(path.resolve('/workspace/test-project'));
+  });
+
+  it('should use custom PROJECT_BASE_DIR when set', async () => {
+    process.env.PROJECT_BASE_DIR = '/custom/projects';
+    
+    const fs = await import('fs');
+    fs.promises.access.mockRejectedValue({ code: 'ENOENT' });
+
+    const result = await addProjectManually('test-project');
+
+    expect(result.path).toBe(path.resolve('/custom/projects/test-project'));
+    expect(result.fullPath).toBe(path.resolve('/custom/projects/test-project'));
+  });
+
+  it('should prevent directory traversal attacks with custom base dir', async () => {
+    process.env.PROJECT_BASE_DIR = '/safe/projects';
+
+    await expect(addProjectManually('../../../etc/passwd')).rejects.toThrow(
+      'Invalid project path. Directory traversal attempts are not allowed.'
+    );
+  });
+
+  it('should validate project names correctly', async () => {
+    process.env.PROJECT_BASE_DIR = '/test/projects';
+
+    await expect(addProjectManually('')).rejects.toThrow('Invalid project name');
+    await expect(addProjectManually('.')).rejects.toThrow('Invalid project name');
+    await expect(addProjectManually('..')).rejects.toThrow('Invalid project name');
+  });
+
+  it('should generate correct project identifier for session linking', async () => {
+    process.env.PROJECT_BASE_DIR = '/custom/base';
+    
+    const fs = await import('fs');
+    fs.promises.access.mockRejectedValue({ code: 'ENOENT' });
+
+    const result = await addProjectManually('my-project');
+
+    // Project identifier should be encoded path for session storage
+    const expectedPath = path.resolve('/custom/base/my-project');
+    const expectedIdentifier = expectedPath.replace(/\//g, '-');
+    expect(result.name).toBe(expectedIdentifier);
+  });
+});

--- a/server/utils/platform.js
+++ b/server/utils/platform.js
@@ -6,17 +6,19 @@
  * Get dangerous system paths that should be restricted for security
  * @returns {string[]} Array of dangerous system paths
  */
-function getDangerousSystemPaths() {
+export function getDangerousSystemPaths() {
   const commonPaths = ['/etc', '/usr', '/var', '/sys', '/proc'];
   
   if (process.platform === 'win32') {
+    // Use dynamic system drive detection instead of hardcoded 'C:'
+    const systemDrive = process.env.SystemDrive || 'C:';
     return [
       ...commonPaths,
-      'C:\\Windows',
-      'C:\\Program Files', 
-      'C:\\Program Files (x86)',
-      'C:\\ProgramData',
-      'C:\\System Volume Information'
+      `${systemDrive}\\Windows`,
+      `${systemDrive}\\Program Files`, 
+      `${systemDrive}\\Program Files (x86)`,
+      `${systemDrive}\\ProgramData`,
+      `${systemDrive}\\System Volume Information`
     ];
   }
   
@@ -27,7 +29,7 @@ function getDangerousSystemPaths() {
  * Get allowed base path patterns for project creation
  * @returns {string[]} Array of allowed base path patterns
  */
-function getAllowedBasePathPatterns() {
+export function getAllowedBasePathPatterns() {
   if (process.platform === 'win32') {
     return [
       /^[A-Za-z]:\\workspace/,
@@ -53,7 +55,7 @@ function getAllowedBasePathPatterns() {
  * @param {string} absolutePath - The absolute path to validate
  * @returns {boolean} True if path is safe, false otherwise
  */
-function isSafeProjectPath(absolutePath) {
+export function isSafeProjectPath(absolutePath) {
   const dangerousPaths = getDangerousSystemPaths();
   
   // Check if path starts with any dangerous system path
@@ -71,7 +73,7 @@ function isSafeProjectPath(absolutePath) {
  * @param {string} absolutePath - The absolute path to validate
  * @returns {boolean} True if path matches allowed patterns, false otherwise
  */
-function matchesAllowedPattern(absolutePath) {
+export function matchesAllowedPattern(absolutePath) {
   const allowedPatterns = getAllowedBasePathPatterns();
   
   return allowedPatterns.some(pattern => pattern.test(absolutePath));
@@ -82,7 +84,7 @@ function matchesAllowedPattern(absolutePath) {
  * @param {string} pathStr - The path string to validate
  * @returns {boolean} True if path format is valid for current platform
  */
-function isValidPathFormat(pathStr) {
+export function isValidPathFormat(pathStr) {
   if (process.platform === 'win32') {
     // Windows: Must have drive letter (C:\, D:\, etc.)
     return /^[A-Za-z]:\\/.test(pathStr);
@@ -96,7 +98,7 @@ function isValidPathFormat(pathStr) {
  * Get platform-specific path separator
  * @returns {string} Path separator for current platform
  */
-function getPathSeparator() {
+export function getPathSeparator() {
   return process.platform === 'win32' ? '\\' : '/';
 }
 
@@ -105,19 +107,10 @@ function getPathSeparator() {
  * @param {string} pathStr - The path string to normalize
  * @returns {string} Path with normalized separators
  */
-function normalizePlatformPath(pathStr) {
+export function normalizePlatformPath(pathStr) {
   const separator = getPathSeparator();
   const oppositeSeparator = separator === '\\' ? '/' : '\\';
   
   return pathStr.replace(new RegExp(`\\${oppositeSeparator}`, 'g'), separator);
 }
 
-module.exports = {
-  getDangerousSystemPaths,
-  getAllowedBasePathPatterns,
-  isSafeProjectPath,
-  matchesAllowedPattern,
-  isValidPathFormat,
-  getPathSeparator,
-  normalizePlatformPath
-};

--- a/server/utils/platform.js
+++ b/server/utils/platform.js
@@ -1,0 +1,123 @@
+/**
+ * Platform-specific utility functions for cross-platform path and system validation
+ */
+
+/**
+ * Get dangerous system paths that should be restricted for security
+ * @returns {string[]} Array of dangerous system paths
+ */
+function getDangerousSystemPaths() {
+  const commonPaths = ['/etc', '/usr', '/var', '/sys', '/proc'];
+  
+  if (process.platform === 'win32') {
+    return [
+      ...commonPaths,
+      'C:\\Windows',
+      'C:\\Program Files', 
+      'C:\\Program Files (x86)',
+      'C:\\ProgramData',
+      'C:\\System Volume Information'
+    ];
+  }
+  
+  return [...commonPaths, '/boot', '/bin', '/sbin', '/root'];
+}
+
+/**
+ * Get allowed base path patterns for project creation
+ * @returns {string[]} Array of allowed base path patterns
+ */
+function getAllowedBasePathPatterns() {
+  if (process.platform === 'win32') {
+    return [
+      /^[A-Za-z]:\\workspace/,
+      /^[A-Za-z]:\\projects/,
+      /^[A-Za-z]:\\dev/,
+      /^[A-Za-z]:\\code/,
+      /^[A-Za-z]:\\Users\\[^\\]+\\(workspace|projects|dev|code)/
+    ];
+  }
+  
+  return [
+    /^\/workspace/,
+    /^\/projects/, 
+    /^\/dev/,
+    /^\/code/,
+    /^\/home\/[^/]+\/(workspace|projects|dev|code)/,
+    /^\/Users\/[^/]+\/(workspace|projects|dev|code)/
+  ];
+}
+
+/**
+ * Check if a path is considered safe for project creation
+ * @param {string} absolutePath - The absolute path to validate
+ * @returns {boolean} True if path is safe, false otherwise
+ */
+function isSafeProjectPath(absolutePath) {
+  const dangerousPaths = getDangerousSystemPaths();
+  
+  // Check if path starts with any dangerous system path
+  for (const dangerousPath of dangerousPaths) {
+    if (absolutePath.startsWith(dangerousPath)) {
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+/**
+ * Check if a path matches allowed base path patterns
+ * @param {string} absolutePath - The absolute path to validate
+ * @returns {boolean} True if path matches allowed patterns, false otherwise
+ */
+function matchesAllowedPattern(absolutePath) {
+  const allowedPatterns = getAllowedBasePathPatterns();
+  
+  return allowedPatterns.some(pattern => pattern.test(absolutePath));
+}
+
+/**
+ * Validate platform-specific path format
+ * @param {string} pathStr - The path string to validate
+ * @returns {boolean} True if path format is valid for current platform
+ */
+function isValidPathFormat(pathStr) {
+  if (process.platform === 'win32') {
+    // Windows: Must have drive letter (C:\, D:\, etc.)
+    return /^[A-Za-z]:\\/.test(pathStr);
+  }
+  
+  // Unix-like: Must start with /
+  return pathStr.startsWith('/');
+}
+
+/**
+ * Get platform-specific path separator
+ * @returns {string} Path separator for current platform
+ */
+function getPathSeparator() {
+  return process.platform === 'win32' ? '\\' : '/';
+}
+
+/**
+ * Normalize path separators for current platform
+ * @param {string} pathStr - The path string to normalize
+ * @returns {string} Path with normalized separators
+ */
+function normalizePlatformPath(pathStr) {
+  const separator = getPathSeparator();
+  const oppositeSeparator = separator === '\\' ? '/' : '\\';
+  
+  return pathStr.replace(new RegExp(`\\${oppositeSeparator}`, 'g'), separator);
+}
+
+module.exports = {
+  getDangerousSystemPaths,
+  getAllowedBasePathPatterns,
+  isSafeProjectPath,
+  matchesAllowedPattern,
+  isValidPathFormat,
+  getPathSeparator,
+  normalizePlatformPath
+};

--- a/server/utils/platform.test.js
+++ b/server/utils/platform.test.js
@@ -48,6 +48,27 @@ describe('Platform Utilities', () => {
       expect(paths).toContain('C:\\ProgramData');
       expect(paths).toContain('C:\\System Volume Information');
     });
+
+    it('should use SystemDrive environment variable on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const originalSystemDrive = process.env.SystemDrive;
+      
+      // Test with custom system drive
+      process.env.SystemDrive = 'D:';
+      
+      const paths = getDangerousSystemPaths();
+      
+      expect(paths).toContain('D:\\Windows');
+      expect(paths).toContain('D:\\Program Files');
+      expect(paths).toContain('D:\\Program Files (x86)');
+      
+      // Restore original value
+      if (originalSystemDrive !== undefined) {
+        process.env.SystemDrive = originalSystemDrive;
+      } else {
+        delete process.env.SystemDrive;
+      }
+    });
   });
 
   describe('getAllowedBasePathPatterns', () => {

--- a/server/utils/platform.test.js
+++ b/server/utils/platform.test.js
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getDangerousSystemPaths,
+  getAllowedBasePathPatterns,
+  isSafeProjectPath,
+  matchesAllowedPattern,
+  isValidPathFormat,
+  getPathSeparator,
+  normalizePlatformPath
+} from './platform.js';
+
+describe('Platform Utilities', () => {
+  let originalPlatform;
+  
+  beforeEach(() => {
+    originalPlatform = process.platform;
+  });
+  
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  describe('getDangerousSystemPaths', () => {
+    it('should return common dangerous paths for Unix-like systems', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      const paths = getDangerousSystemPaths();
+      
+      expect(paths).toContain('/etc');
+      expect(paths).toContain('/usr');
+      expect(paths).toContain('/var');
+      expect(paths).toContain('/sys');
+      expect(paths).toContain('/proc');
+      expect(paths).toContain('/boot');
+      expect(paths).toContain('/bin');
+      expect(paths).toContain('/sbin');
+      expect(paths).toContain('/root');
+    });
+
+    it('should return Windows-specific dangerous paths for win32', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      const paths = getDangerousSystemPaths();
+      
+      expect(paths).toContain('C:\\Windows');
+      expect(paths).toContain('C:\\Program Files');
+      expect(paths).toContain('C:\\Program Files (x86)');
+      expect(paths).toContain('C:\\ProgramData');
+      expect(paths).toContain('C:\\System Volume Information');
+    });
+  });
+
+  describe('getAllowedBasePathPatterns', () => {
+    it('should return Unix-like path patterns for non-Windows systems', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      const patterns = getAllowedBasePathPatterns();
+      
+      expect(patterns).toHaveLength(6);
+      expect(patterns[0].test('/workspace/project')).toBe(true);
+      expect(patterns[1].test('/projects/myapp')).toBe(true);
+      expect(patterns[2].test('/dev/test')).toBe(true);
+      expect(patterns[3].test('/code/app')).toBe(true);
+      expect(patterns[4].test('/home/user/workspace/project')).toBe(true);
+      expect(patterns[5].test('/Users/jane/dev/app')).toBe(true);
+    });
+
+    it('should return Windows path patterns for win32', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      const patterns = getAllowedBasePathPatterns();
+      
+      expect(patterns).toHaveLength(5);
+      expect(patterns[0].test('C:\\workspace\\project')).toBe(true);
+      expect(patterns[1].test('D:\\projects\\myapp')).toBe(true);
+      expect(patterns[2].test('C:\\dev\\test')).toBe(true);
+      expect(patterns[3].test('E:\\code\\app')).toBe(true);
+      expect(patterns[4].test('C:\\Users\\john\\workspace\\project')).toBe(true);
+    });
+  });
+
+  describe('isSafeProjectPath', () => {
+    it('should return false for dangerous system paths on Unix', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(isSafeProjectPath('/etc/passwd')).toBe(false);
+      expect(isSafeProjectPath('/usr/bin/test')).toBe(false);
+      expect(isSafeProjectPath('/var/log/app')).toBe(false);
+      expect(isSafeProjectPath('/sys/kernel')).toBe(false);
+      expect(isSafeProjectPath('/proc/meminfo')).toBe(false);
+      expect(isSafeProjectPath('/boot/grub')).toBe(false);
+      expect(isSafeProjectPath('/bin/bash')).toBe(false);
+      expect(isSafeProjectPath('/sbin/init')).toBe(false);
+      expect(isSafeProjectPath('/root/.ssh')).toBe(false);
+    });
+
+    it('should return false for dangerous system paths on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      expect(isSafeProjectPath('C:\\Windows\\System32')).toBe(false);
+      expect(isSafeProjectPath('C:\\Program Files\\App')).toBe(false);
+      expect(isSafeProjectPath('C:\\Program Files (x86)\\Tool')).toBe(false);
+      expect(isSafeProjectPath('C:\\ProgramData\\Config')).toBe(false);
+      expect(isSafeProjectPath('C:\\System Volume Information\\Data')).toBe(false);
+    });
+
+    it('should return true for safe project paths', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(isSafeProjectPath('/workspace/myproject')).toBe(true);
+      expect(isSafeProjectPath('/projects/webapp')).toBe(true);
+      expect(isSafeProjectPath('/home/user/dev/app')).toBe(true);
+      expect(isSafeProjectPath('/opt/custom/project')).toBe(true);
+    });
+  });
+
+  describe('matchesAllowedPattern', () => {
+    it('should match allowed patterns correctly on Unix', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(matchesAllowedPattern('/workspace/project')).toBe(true);
+      expect(matchesAllowedPattern('/projects/app')).toBe(true);
+      expect(matchesAllowedPattern('/dev/test')).toBe(true);
+      expect(matchesAllowedPattern('/code/myapp')).toBe(true);
+      expect(matchesAllowedPattern('/home/john/workspace/project')).toBe(true);
+      expect(matchesAllowedPattern('/Users/jane/dev/app')).toBe(true);
+      
+      expect(matchesAllowedPattern('/random/path')).toBe(false);
+      expect(matchesAllowedPattern('/etc/config')).toBe(false);
+    });
+
+    it('should match allowed patterns correctly on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      expect(matchesAllowedPattern('C:\\workspace\\project')).toBe(true);
+      expect(matchesAllowedPattern('D:\\projects\\app')).toBe(true);
+      expect(matchesAllowedPattern('E:\\dev\\test')).toBe(true);
+      expect(matchesAllowedPattern('F:\\code\\myapp')).toBe(true);
+      expect(matchesAllowedPattern('C:\\Users\\john\\workspace\\project')).toBe(true);
+      
+      expect(matchesAllowedPattern('C:\\Random\\Path')).toBe(false);
+      expect(matchesAllowedPattern('C:\\Windows\\System32')).toBe(false);
+    });
+  });
+
+  describe('isValidPathFormat', () => {
+    it('should validate Unix path format correctly', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(isValidPathFormat('/absolute/path')).toBe(true);
+      expect(isValidPathFormat('/workspace')).toBe(true);
+      expect(isValidPathFormat('/')).toBe(true);
+      
+      expect(isValidPathFormat('relative/path')).toBe(false);
+      expect(isValidPathFormat('./current/path')).toBe(false);
+      expect(isValidPathFormat('../parent/path')).toBe(false);
+    });
+
+    it('should validate Windows path format correctly', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      expect(isValidPathFormat('C:\\absolute\\path')).toBe(true);
+      expect(isValidPathFormat('D:\\workspace')).toBe(true);
+      expect(isValidPathFormat('E:\\')).toBe(true);
+      
+      expect(isValidPathFormat('\\relative\\path')).toBe(false);
+      expect(isValidPathFormat('relative\\path')).toBe(false);
+      expect(isValidPathFormat('.\\current\\path')).toBe(false);
+      expect(isValidPathFormat('..\\parent\\path')).toBe(false);
+    });
+  });
+
+  describe('getPathSeparator', () => {
+    it('should return correct separator for Unix systems', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(getPathSeparator()).toBe('/');
+    });
+
+    it('should return correct separator for Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      expect(getPathSeparator()).toBe('\\');
+    });
+  });
+
+  describe('normalizePlatformPath', () => {
+    it('should normalize path separators for Unix systems', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      
+      expect(normalizePlatformPath('path\\with\\backslashes')).toBe('path/with/backslashes');
+      expect(normalizePlatformPath('path/with/forward/slashes')).toBe('path/with/forward/slashes');
+      expect(normalizePlatformPath('mixed\\and/separators')).toBe('mixed/and/separators');
+    });
+
+    it('should normalize path separators for Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      
+      expect(normalizePlatformPath('path/with/forward/slashes')).toBe('path\\with\\forward\\slashes');
+      expect(normalizePlatformPath('path\\with\\backslashes')).toBe('path\\with\\backslashes');
+      expect(normalizePlatformPath('mixed/and\\separators')).toBe('mixed\\and\\separators');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ✅ Adds `PROJECT_BASE_DIR` environment variable for configurable project folder creation
- ✅ Maintains backward compatibility (defaults to `/workspace/` when not set)
- ✅ Enhanced directory traversal attack prevention
- ✅ Claude sessions remain unchanged in `~/.claude/projects/`
- ✅ Project-to-session linking preserved via encoded path identifiers

## Technical Implementation
- Modified `addProjectManually()` function in `server/projects.js` to use environment variable
- Updated `.env.example` with clear documentation
- Added comprehensive test suite covering all scenarios
- Enhanced security validation with early directory traversal detection

## Test Coverage
- ✅ Default behavior (`/workspace/` when `PROJECT_BASE_DIR` not set)
- ✅ Custom directory configuration
- ✅ Directory traversal attack prevention
- ✅ Invalid project name validation
- ✅ Session linking identifier generation

## Usage
```bash
# Set in .env file
PROJECT_BASE_DIR=/custom/projects

# Create project "my-app" 
# → Creates folder at: /custom/projects/my-app
# → Claude sessions at: ~/.claude/projects/-custom-projects-my-app/
```

## Breaking Changes
None - fully backward compatible.

Fixes the hardcoded `/workspace/` limitation, allowing users to organize projects in their preferred location.